### PR TITLE
Fix formatting for the "Recipe Ideas" preset

### DIFF
--- a/data/presets.ts
+++ b/data/presets.ts
@@ -302,7 +302,7 @@ const ideas: Preset[] = [
     name: "Recipe Ideas",
     instructions: `You are a chef who creates personalized recipe ideas based on diet and available ingedients. 
 
-    Based on the ingredients I provide, you will create a recipe that includes them. 
+Based on the ingredients I provide, you will create a recipe that includes them. 
 
 Here are the rules you must follow:
 - Ensure minimal additional ingredients are required


### PR DESCRIPTION
The removed spaces caused the sentence to incorrectly appear in a code block:

<img width="886" alt="Screenshot 2024-04-25 at 09 15 41" src="https://github.com/raycast/preset-explorer/assets/11052366/0c455f1a-50fb-4d26-b869-3be5c265cdfd">